### PR TITLE
🩹 fix: stop listening to the EditContext validation event

### DIFF
--- a/Demo/Client/Pages/Kit/Focus/FocusFirstFieldOnInvalidSubmitExample.razor
+++ b/Demo/Client/Pages/Kit/Focus/FocusFirstFieldOnInvalidSubmitExample.razor
@@ -1,12 +1,16 @@
-﻿@using BlazorDevKit
-@using System.ComponentModel.DataAnnotations
+﻿@using System.ComponentModel.DataAnnotations
 <EditForm Model="this">
     <DataAnnotationsValidator/>
     <BdkFocusFirstFieldOnInvalidSubmit/>
     <InputText class="@Bs.Css.FormControl" @bind-Value="Name"/>
+    <br/>
+    <InputText class="@Bs.Css.FormControl" @bind-Value="Email"/>
     <BsButton Class="@Bs.Css.MarginTop2" Variant="BsButtonVariant.Primary" Type="BsButtonType.Submit">Submit</BsButton>
 </EditForm>
 @code{
     [Required]
     public string? Name { get; set; }
+    
+    [EmailAddress, Required]
+    public string? Email { get; set; }
 }

--- a/Kit/Core/Components/Focus/BdkFocusFirstFieldOnInvalidSubmit.razor.cs
+++ b/Kit/Core/Components/Focus/BdkFocusFirstFieldOnInvalidSubmit.razor.cs
@@ -9,9 +9,9 @@ public partial class BdkFocusFirstFieldOnInvalidSubmit : ComponentBase, IAsyncDi
     private ElementReference _elementReference;
     private IJSObjectReference? _jsModuleReference;
     private IJSObjectReference? _jsInstanceReference;
+    private string _id = Guid.NewGuid().ToString("N");
 
     [Inject] public required IJSRuntime JsRuntime { get; set; }
-    [CascadingParameter] public required EditContext EditContext { get; set; }
     
     /// <summary>
     /// By default, the ‘invalid’ class is added to the field that is invalid when the form is submitted and validated by EditContext.
@@ -31,26 +31,28 @@ public partial class BdkFocusFirstFieldOnInvalidSubmit : ComponentBase, IAsyncDi
             _jsModuleReference = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorDevKit.Core/Components/Focus/BdkFocusFirstFieldOnInvalidSubmit.razor.js");
             _jsInstanceReference = await _jsModuleReference
                 .InvokeAsync<IJSObjectReference>(
-                    "BdkFocusFirstFieldOnInvalidSubmit.create", 
+                    "BdkFocusFirstFieldOnInvalidSubmit.create",
+                    _id,
+                    DotNetObjectReference.Create(this),
                     _elementReference,
                     InvalidClass
                 );
             
-            EditContext.OnValidationStateChanged += ValidationStateChanged;
         }
     }
 
-    private async void ValidationStateChanged(object? sender, ValidationStateChangedEventArgs e)
+    [JSInvokable]
+    public async Task NotifySubmitAsync()
     {
         if(_jsInstanceReference is null) return;
         await _jsInstanceReference.InvokeVoidAsync("validationChangedAsync", Force);
     }
-
+    
     public async ValueTask DisposeAsync()
     {
         if(_jsInstanceReference is not null)
         {
-            await _jsInstanceReference.InvokeVoidAsync("dispose");
+            await _jsInstanceReference.InvokeVoidAsync("dispose", _id);
             await _jsInstanceReference.DisposeAsync();
         }
 
@@ -58,7 +60,5 @@ public partial class BdkFocusFirstFieldOnInvalidSubmit : ComponentBase, IAsyncDi
         {
             await _jsModuleReference.DisposeAsync();
         }
-        
-        EditContext.OnValidationStateChanged -= ValidationStateChanged;
     }
 }

--- a/Kit/Core/Components/Focus/BdkFocusFirstFieldOnInvalidSubmit.razor.js
+++ b/Kit/Core/Components/Focus/BdkFocusFirstFieldOnInvalidSubmit.razor.js
@@ -1,7 +1,8 @@
 export class BdkFocusFirstFieldOnInvalidSubmit {
 
-    constructor(elementReference, invalidClass) {
+    constructor(dotNetReference, elementReference, invalidClass) {
         this.invalidClass = invalidClass;
+        this.dotNetReference = dotNetReference;
         this.form = elementReference.closest('form');
     }
 
@@ -27,18 +28,21 @@ export class BdkFocusFirstFieldOnInvalidSubmit {
         } else {
             console.log('The .invalid input is not focusable');
         }
-    }
+    }    
     
     isFocusable(element) {
         return element.tabIndex >= 0;
     }
     
-    dispose() {
+    dispose(identifier) {
         this.form = null;
+        delete window[identifier];
     }
 
-    static create(elementReference, invalidClass) {
-        return new BdkFocusFirstFieldOnInvalidSubmit(elementReference, invalidClass);
+    static create(identifier, dotNetReference, elementReference, invalidClass) {
+        window[identifier] = new BdkFocusFirstFieldOnInvalidSubmit(dotNetReference, elementReference, invalidClass);
+        window[identifier].form.addEventListener('submit', () => window[identifier].dotNetReference.invokeMethodAsync('NotifySubmitAsync'));
+        return window[identifier];        
     }
 }
 


### PR DESCRIPTION
It caused strange behavior, as it is invoked at several possible times, causing the focus to switch to another input when the user starts typing